### PR TITLE
feat: do not allow interactive prompts.

### DIFF
--- a/src/base-emulator.js
+++ b/src/base-emulator.js
@@ -147,7 +147,7 @@ class BaseEmulator {
    * @protected
    */
   _getCommandParameters() {
-    const params = ['beta', 'emulators', 'datastore', 'start'];
+    const params = ['-q', 'beta', 'emulators', 'datastore', 'start'];
 
     if (this._options.project) {
       params.push(...['--project', this._options.project]);


### PR DESCRIPTION
gcloud may all kinds of questions, especially when started for the first time.  This can be suppressed by setting `CLOUDSDK_CORE_DISABLE_PROMPTS=1` in the environment or by using the `-q` parameter. See `gclound --help` for documentation.