### PR TITLE
Set Environment Variables as per Emulator Doc

### DIFF
--- a/src/base-emulator.js
+++ b/src/base-emulator.js
@@ -135,10 +135,14 @@ class BaseEmulator {
    */
   _setEnviromentVariables() {
     process.env.DATASTORE_EMULATOR_HOST = `${this._options.host}:${this._options.port}`;
-
+    process.env.DATASTORE_EMULATOR_HOST_PATH = `${this._options.host}:${this._options.port}/datastore`
+    process.env.DATASTORE_HOST = `http://${this._options.host}:${this._options.port}`
+    process.env.DATASTORE_DATASET = 'test'
+    
     if (!process.env.DATASTORE_PROJECT_ID && this._options.project) {
       process.env.DATASTORE_PROJECT_ID = this._options.project
     }
+    process.env.GCLOUD_PROJECT = process.env.DATASTORE_PROJECT_ID
   }
 
   /**

--- a/src/base-emulator.js
+++ b/src/base-emulator.js
@@ -137,12 +137,11 @@ class BaseEmulator {
     process.env.DATASTORE_EMULATOR_HOST = `${this._options.host}:${this._options.port}`;
     process.env.DATASTORE_EMULATOR_HOST_PATH = `${this._options.host}:${this._options.port}/datastore`
     process.env.DATASTORE_HOST = `http://${this._options.host}:${this._options.port}`
-    process.env.DATASTORE_DATASET = 'test'
-    
+    process.env.DATASTORE_DATASET = this._options.project
+
     if (!process.env.DATASTORE_PROJECT_ID && this._options.project) {
       process.env.DATASTORE_PROJECT_ID = this._options.project
     }
-    process.env.GCLOUD_PROJECT = process.env.DATASTORE_PROJECT_ID
   }
 
   /**

--- a/test/locally-installed-sdk.spec.js
+++ b/test/locally-installed-sdk.spec.js
@@ -286,6 +286,33 @@ describe('Locally Installed Google DataStore Emulator Test', () => {
       })
   });
 
+  it('should set environment variables', () => {
+    process.env.GCLOUD_PROJECT = 'my-test-GCLOUD_PROJECT';
+    let options = {
+      debug: true,
+      port: 8081,
+    };
+
+    let emulator = new Emulator(options);
+
+    return emulator.start()
+      .then(() => {
+        expect(process.env.DATASTORE_EMULATOR_HOST).to.be.equal(`localhost:8081`);
+        expect(process.env.DATASTORE_EMULATOR_HOST_PATH).to.be.equal(`localhost:8081/datastore`);
+        expect(process.env.DATASTORE_HOST).to.be.equal(`http://localhost:8081`);
+        // shouldn't this be the same as GCLOUD_PROJECT, but they don't
+        // see: https://gist.github.com/mdornseif/d9bd0c55a7aab298d0a29bee124302c8
+        expect(process.env.DATASTORE_DATASET).to.be.equal(`test`);
+        expect(process.env.DATASTORE_PROJECT_ID).to.be.equal(`test`);
+        // These should not fail, but they do
+        // expect(process.env.DATASTORE_DATASET).to.be.equal(`my-test-GCLOUD_PROJECT`);
+        // expect(process.env.DATASTORE_PROJECT_ID).to.be.equal(`my-test-GCLOUD_PROJECT`);
+      })
+      .then((result) => {
+        return emulator.stop()
+      })
+  });
+
   it('should not start twice', () => {
     process.env.GCLOUD_PROJECT = 'test';
 


### PR DESCRIPTION
It seems that some Client Librarys need more environment variables. https://cloud.google.com/datastore/docs/tools/datastore-emulator#manually_setting_the_variables does not really say which environment variable is used for what. So better set them all to be compatible.