### PR TITLE
Dynamic Port Selection

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -37,7 +37,7 @@ interface Options {
   /**
    * Default: 8081
    *
-   * If it is empty the emulator selects a random free port. If use docker version always set port.
+   * Preferred port number. The docker version always uses 8081.
    */
   port?: number;
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "dockerode": "^3.2.1",
     "fs-extra": "^10.0.0",
     "node-cleanup": "^2.1.2",
+    "portfinder": "^1.0.28",
     "tree-kill": "^1.2.2"
   },
   "devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -65,7 +65,7 @@ storeOnDisk (boolean) | false | The datastore either persists the entities on di
 dataDir (string) | empty | The emulator creates a directory where the project files are stored. If it is empty the emulator default value will be used. You could set relative ./directory or absolute path /tmp/dir1/dir2/. If this directory does not exist, it will be created. **Bug** : With linux Docker host don't delete the folder
 clean (boolean) | true | If dataDir value is set and 'clean' value is true then the package deletes the dataDir. The package **does not** delete the gcloud emulator default directory. 
 host (string) | localhost | If it is empty the'localhost' of google default value is used. It can take the form of a single address (hostname, IPv4, or IPv6)
-port (number) | 8081 | If it is empty the emulator selects a random free port. If use docker version always set port.
+port (number) | 8081 | Preferred port number. The docker version always uses 8081.
 debug (boolean) | false | If it is true, it writes the console.logs of the emulator onto the main process console.
 consistency (string) | '1.0' | The consistency level of the Datastore Emulator. [More details](https://cloud.google.com/sdk/gcloud/reference/beta/emulators/datastore/start) 
 useDocker (boolean) | false | If it is true, it use docker image to run emulator instead of locally installed version.

--- a/src/base-emulator.js
+++ b/src/base-emulator.js
@@ -135,14 +135,10 @@ class BaseEmulator {
    */
   _setEnviromentVariables() {
     process.env.DATASTORE_EMULATOR_HOST = `${this._options.host}:${this._options.port}`;
-    process.env.DATASTORE_EMULATOR_HOST_PATH = `${this._options.host}:${this._options.port}/datastore`
-    process.env.DATASTORE_HOST = `http://${this._options.host}:${this._options.port}`
-    process.env.DATASTORE_DATASET = 'test'
-    
+
     if (!process.env.DATASTORE_PROJECT_ID && this._options.project) {
       process.env.DATASTORE_PROJECT_ID = this._options.project
     }
-    process.env.GCLOUD_PROJECT = process.env.DATASTORE_PROJECT_ID
   }
 
   /**

--- a/src/base-emulator.js
+++ b/src/base-emulator.js
@@ -135,10 +135,14 @@ class BaseEmulator {
    */
   _setEnviromentVariables() {
     process.env.DATASTORE_EMULATOR_HOST = `${this._options.host}:${this._options.port}`;
-
+    process.env.DATASTORE_EMULATOR_HOST_PATH = `${this._options.host}:${this._options.port}/datastore`
+    process.env.DATASTORE_HOST = `http://${this._options.host}:${this._options.port}`
+    process.env.DATASTORE_DATASET = 'test'
+    
     if (!process.env.DATASTORE_PROJECT_ID && this._options.project) {
       process.env.DATASTORE_PROJECT_ID = this._options.project
     }
+    process.env.GCLOUD_PROJECT = process.env.DATASTORE_PROJECT_ID
   }
 
   /**

--- a/src/locally-installed-sdk.js
+++ b/src/locally-installed-sdk.js
@@ -5,6 +5,7 @@ const kill = require('tree-kill');
 
 const EmulatorStates = require('./emulator-states');
 const BaseEmulator = require('./base-emulator');
+const portfinder = require('portfinder');
 
 /**
  * Wrapper for the locally installed SDK
@@ -27,12 +28,16 @@ class LocallyInstalledSdk extends BaseEmulator {
       if (this._state)
         throw new Error('Datastore emulator is already running.');
 
-      super._start(resolve, reject);
+        portfinder.getPortPromise({port: this._options.port}).then(port => {
+        this._options.port = port
+        console.log(port, this._options.port)
+        super._start(resolve, reject);
+        const params = this._getCommandParameters();
+        console.log(params)
+        self._emulator = spawn('gcloud', params, { shell: true });
 
-      const params = this._getCommandParameters();
-      self._emulator = spawn('gcloud', params, { shell: true });
-
-      self._registerEmulatorListeners();
+        self._registerEmulatorListeners();
+      })
     })
 
   }


### PR DESCRIPTION
I had serious issues with google-datastore-emulator not being able to be run in parallel tests.
The issue was port selection: At least in the default configuration the port was not selected dynamically. 

This PR solves that in considering the provided port number as PREFERRED port. If this port is not free, the next free port will be selected. So instantiation should never vail due to listen port not available.