### PR TITLE
fix: throw proper exception when emulator can't start because port already in used

### DIFF
--- a/src/base-emulator.js
+++ b/src/base-emulator.js
@@ -1,5 +1,6 @@
 'use strict';
 const DEV_APP_SERVER_RUNNING_KEY = '[datastore] Dev App Server is now running.';
+const DEV_APP_PORT_BIND_ERROR = '[datastore] Exiting due to exception: java.io.IOException: Failed to bind';
 
 const EventEmitter = require('events');
 const fse = require('fs-extra');
@@ -42,11 +43,14 @@ class BaseEmulator {
       self._stateEmitter.removeListener(EmulatorStates.RUNNING, startSuccessListener);
 
       self._stateEmitter.removeListener(EmulatorStates.CLOSE, startRejectListener);
+      self._stateEmitter.removeListener(EmulatorStates.ERROR, startRejectListener);
+
     }
 
     self._stateEmitter.on(EmulatorStates.RUNNING, startSuccessListener);
 
     self._stateEmitter.on(EmulatorStates.CLOSE, startRejectListener);
+    self._stateEmitter.on(EmulatorStates.ERROR, startRejectListener);
   }
 
   /**
@@ -101,6 +105,8 @@ class BaseEmulator {
     if (text.indexOf(DEV_APP_SERVER_RUNNING_KEY) > -1) {
       this._setEnviromentVariables();
       this._setState(EmulatorStates.RUNNING);
+    } else if (text.includes(DEV_APP_PORT_BIND_ERROR)) {
+      this._setState(EmulatorStates.ERROR, new Error(`"${this._options.host}:${this._options.port}" port already in use!`));
     }
   }
 

--- a/test/docker-sdk.spec.js
+++ b/test/docker-sdk.spec.js
@@ -359,4 +359,26 @@ envDescribe('Docker Container Google DataStore Emulator Test', () => {
         process.kill(process.pid);
       })
   })
+
+  it('should throw proper exception when port already in use', async () => {
+    const options = {
+      debug: true,
+      port: 8081
+    };
+    let emulator1, emulator2;
+    let emulator1Started = false;
+    try {
+      emulator1 = new Emulator(options);
+      await emulator1.start();
+      emulator1Started = true;
+      emulator2 = new Emulator(options);
+      await emulator2.start();
+    } catch (error) {
+      expect(emulator1Started).to.be.true;
+      expect(error.message).to.be.equal('"localhost:8081" port already in use!')
+    } finally {
+      await emulator1.stop();
+      await emulator2.stop();
+    }
+  })
 });

--- a/test/locally-installed-sdk.spec.js
+++ b/test/locally-installed-sdk.spec.js
@@ -361,6 +361,29 @@ describe('Locally Installed Google DataStore Emulator Test', () => {
       await emulator.stop();
     }
   })
+
+  it('should throw proper exception when port already in use', async () => {
+    const options = {
+      debug: true,
+      port: 8081
+    };
+    let emulator1, emulator2;
+    let emulator1Started = false;
+    try {
+      emulator1 = new Emulator(options);
+      await emulator1.start();
+      emulator1Started = true;
+      emulator2 = new Emulator(options);
+      await emulator2.start();
+    } catch (error) {
+      expect(emulator1Started).to.be.true;
+      expect(error.message).to.be.equal('"localhost:8081" port already in use!')
+    } finally {
+      await emulator1.stop();
+      await emulator2.stop();
+    }
+  })
+
 });
 
 describe('Consistency test', () => {


### PR DESCRIPTION
Example: `"localhost:8081" port already in use!`