### PR TITLE
deps: allow @google-cloud/datastore 7.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
     "standard-version": "^9.0.0"
   },
   "peerDependencies": {
-    "@google-cloud/datastore": ">=1.0.0 <7.0.0"
+    "@google-cloud/datastore": ">=1.0.0 <8.0.0"
   }
 }


### PR DESCRIPTION
@google-cloud/datastore 7.0.0 has been released. I tested with the `npm i --force` option and it still works for me.