### PR TITLE
fix: handle other port already in use error message

### DIFF
--- a/src/base-emulator.js
+++ b/src/base-emulator.js
@@ -1,12 +1,12 @@
 'use strict';
 const DEV_APP_SERVER_RUNNING_KEY = '[datastore] Dev App Server is now running.';
-const DEV_APP_PORT_BIND_ERROR = '[datastore] Exiting due to exception: java.io.IOException: Failed to bind';
 
 const EventEmitter = require('events');
 const fse = require('fs-extra');
 
 const EmulatorStates = require('./emulator-states');
 const getConsistencyArg = require('./get-consistency-arg')
+const isPortAlreadyInUse = require('./is-port-already-in-use')
 class DataStoreStateEmitter extends EventEmitter {
 }
 
@@ -105,7 +105,7 @@ class BaseEmulator {
     if (text.indexOf(DEV_APP_SERVER_RUNNING_KEY) > -1) {
       this._setEnviromentVariables();
       this._setState(EmulatorStates.RUNNING);
-    } else if (text.includes(DEV_APP_PORT_BIND_ERROR)) {
+    } else if (isPortAlreadyInUse(text)) {
       this._setState(EmulatorStates.ERROR, new Error(`"${this._options.host}:${this._options.port}" port already in use!`));
     }
   }

--- a/src/is-port-already-in-use.js
+++ b/src/is-port-already-in-use.js
@@ -1,0 +1,11 @@
+const DEV_APP_PORT_BIND_ERRORS = [
+  '[datastore] Exiting due to exception: java.io.IOException: Failed to bind',
+  '[datastore] Exiting due to exception: java.net.BindException: Address already in use',
+]
+
+function isPortAlreadyInUse(text) {
+  return DEV_APP_PORT_BIND_ERRORS
+    .some(message => text.includes(message))
+}
+
+module.exports = isPortAlreadyInUse


### PR DESCRIPTION
New error message '[datastore] Exiting due to exception: java.net.BindException: Address already in use'